### PR TITLE
Expose X-Akismet-Pro-Tip to spam check callers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 *.egg-info
 local-test.py
 .idea
+.tox


### PR DESCRIPTION
Additionally expose the network timeout as a param for the Akismet class to restrict the amount of time is spent spinning and waiting. This is a breaking change to the check API.