### PR TITLE
Added support for check's recheck reason

### DIFF
--- a/akismet/__init__.py
+++ b/akismet/__init__.py
@@ -82,7 +82,7 @@ class Akismet:
 
     def check(self, user_ip, user_agent, comment_author=None, comment_author_email=None, comment_author_url=None,
               comment_content=None, referrer='unknown', blog=None, permalink=None, comment_type=None, blog_lang=None,
-              comment_date=None, comment_post_modified=None, user_role=None, is_test=False):
+              comment_date=None, comment_post_modified=None, user_role=None, is_test=False, recheck_reason=None):
         parameters = self._get_parameters(locals())
         r = self._request(self.get_check_url(), parameters)
         try:


### PR DESCRIPTION
At some point, Akismet added support for `recheck_reason` in the comment check call.
https://akismet.com/development/api/#comment-check

> If you are sending content to Akismet to be rechecked, such as a post that has been edited or old pending comments that you'd like to recheck, include the parameter recheck_reason with a string describing why the content is being rechecked. For example, recheck_reason=edit.

This PR adds support for that.