### PR TITLE
Use == for comparing strings

### DIFF
--- a/akismet/__init__.py
+++ b/akismet/__init__.py
@@ -91,7 +91,7 @@ class Akismet:
             if result is False:
                 return SpamStatus.Ham
             elif result is True:
-                if r.headers.get('X-Akismet-Pro-Tip') is "discard":
+                if r.headers.get('X-Akismet-Pro-Tip') == "discard":
                     return SpamStatus.DefiniteSpam
                 else:
                     return SpamStatus.ProbableSpam


### PR DESCRIPTION
It is the correct approach, and it produces warning on recent Python versions:
akismet/__init__.py:94: SyntaxWarning: "is" with a literal. Did you mean "=="?